### PR TITLE
Refactor ModelConfig into dataclass

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ pip install torch
 from model import KataGoModel, ModelConfig
 import torch
 
+# ModelConfig is a frozen dataclass describing architecture parameters
 config = ModelConfig()
 model = KataGoModel(config)
 batch = torch.randn(2, config.in_channels, config.board_size, config.board_size)


### PR DESCRIPTION
## Summary
- refactor `ModelConfig` into an immutable dataclass
- annotate all fields with type hints and doc metadata
- clarify usage in README example

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68486347eb548321bbfc8d79294eb13c