### PR TITLE
Refactor GTP engine for internal KataGoModel and core features.

### DIFF
--- a/board.py
+++ b/board.py
@@ -1,0 +1,442 @@
+from typing import Optional, Set, Tuple, List, Dict
+import torch
+
+class GoBoard:
+    """
+    Represents a Go board and its state.
+    """
+
+    def __init__(self, size: int):
+        if not isinstance(size, int) or size <= 0:
+            raise ValueError("Board size must be a positive integer.")
+        self.size: int = size
+        self.board: torch.Tensor = torch.zeros((size, size), dtype=torch.int8)
+        self.to_play: int = 1  # 1 for black, -1 for white
+        self.history: List[Tuple[int, int]] = []
+        self.ko_point: Optional[int] = None
+        self.captured_stones: Dict[int, int] = {1: 0, -1: 0}
+        self.PASS_MOVE: int = size * size
+        self.komi: float = 7.5 # Default komi
+
+    def _get_group(self, r_start: int, c_start: int) -> Tuple[Set[Tuple[int, int]], Set[Tuple[int, int]]]:
+        """
+        Finds the connected group of stones and their liberties.
+        Uses Breadth-First Search (BFS).
+
+        Args:
+            r_start (int): Row of the starting stone.
+            c_start (int): Column of the starting stone.
+
+        Returns:
+            Tuple[Set[Tuple[int, int]], Set[Tuple[int, int]]]:
+                A tuple containing:
+                - group_stones: Set of (row, col) tuples for stones in the group.
+                - group_liberties: Set of (row, col) tuples for liberties of the group.
+        """
+        if not (0 <= r_start < self.size and 0 <= c_start < self.size):
+            return set(), set()
+
+        player_color = self.board[r_start, c_start].item()
+        if player_color == 0:
+            return set(), set()
+
+        group_stones: Set[Tuple[int, int]] = set()
+        group_liberties: Set[Tuple[int, int]] = set()
+
+        q: List[Tuple[int, int]] = [(r_start, c_start)]
+        visited: Set[Tuple[int, int]] = {(r_start, c_start)}
+
+        while q:
+            r, c = q.pop(0)
+            group_stones.add((r, c))
+
+            for dr, dc in [(0, 1), (0, -1), (1, 0), (-1, 0)]:
+                nr, nc = r + dr, c + dc
+
+                if 0 <= nr < self.size and 0 <= nc < self.size:
+                    neighbor_stone = self.board[nr, nc].item()
+                    if neighbor_stone == 0:
+                        group_liberties.add((nr, nc))
+                    elif neighbor_stone == player_color and (nr, nc) not in visited:
+                        visited.add((nr, nc))
+                        q.append((nr, nc))
+                # No need to check out of bounds for liberties, as they must be on board
+
+        return group_stones, group_liberties
+
+    def count_liberties(self, r: int, c: int) -> int:
+        """
+        Counts the liberties of the group to which the stone at (r, c) belongs.
+        Returns 0 if (r,c) is empty or out of bounds.
+        """
+        if not (0 <= r < self.size and 0 <= c < self.size) or self.board[r,c] == 0:
+            return 0
+        _, liberties = self._get_group(r, c)
+        return len(liberties)
+
+    def is_legal_move(self, move_index: int, player: Optional[int] = None) -> bool:
+        """
+        Checks if a move is legal.
+        """
+        current_player = player if player is not None else self.to_play
+
+        if move_index == self.PASS_MOVE:
+            return True
+
+        if not (0 <= move_index < self.PASS_MOVE): # Check if move_index is within board bounds
+            return False
+
+        r, c = move_index // self.size, move_index % self.size
+
+        if not (0 <= r < self.size and 0 <= c < self.size): # Should be redundant due to above check
+            return False # Out of bounds
+
+        if self.board[r, c] != 0:
+            return False  # Point is occupied
+
+        if move_index == self.ko_point:
+            return False  # Simple Ko
+
+        # Check for suicide
+        # Temporarily place the stone
+        original_stone = self.board[r, c].item() # Should be 0
+        self.board[r, c] = current_player
+
+        # Check if the placed stone itself has 0 liberties
+        _, liberties_of_played_stone = self._get_group(r,c)
+
+        is_suicide = len(liberties_of_played_stone) == 0
+
+        if is_suicide:
+            # If it has 0 liberties, check if this move captures any opponent stones.
+            # If it captures, it's not suicide.
+            opponent_player = -current_player
+            captured_any = False
+            for dr, dc in [(0, 1), (0, -1), (1, 0), (-1, 0)]:
+                nr, nc = r + dr, c + dc
+                if 0 <= nr < self.size and 0 <= nc < self.size and self.board[nr, nc] == opponent_player:
+                    # Check liberties of this specific opponent group *after* our stone is placed
+                    _, opp_liberties = self._get_group(nr, nc)
+                    if len(opp_liberties) == 0:
+                        captured_any = True
+                        break
+            if not captured_any:
+                self.board[r, c] = original_stone # Revert
+                return False # Suicide
+
+        # Revert temporary placement for the check
+        self.board[r, c] = original_stone
+        return True
+
+    def play_move(self, move_index: int) -> None:
+        """
+        Plays a move on the board.
+        Raises ValueError if the move is illegal.
+        """
+        if not self.is_legal_move(move_index):
+            r,c = (move_index // self.size, move_index % self.size) if move_index != self.PASS_MOVE else (-1,-1)
+            raise ValueError(f"Illegal move: index {move_index} ({r},{c}) for player {self.to_play}. Ko: {self.ko_point}, Board:\n{self.board}")
+
+        player = self.to_play
+
+        # Reset ko point unless a new ko is formed later
+        # This must happen *before* checking captures that might clear the ko condition
+        # but *after* the is_legal_move check for the current ko_point.
+        # The actual ko point for next turn is determined at the end of this function.
+        # For now, we assume no ko unless one is explicitly set.
+        # This local variable `old_ko_point` is not strictly needed now but can be useful for debugging.
+        # old_ko_point = self.ko_point
+        self.ko_point = None
+
+
+        if move_index == self.PASS_MOVE:
+            self.history.append((player, move_index))
+            self.to_play *= -1
+            # self.ko_point = None # Already done above
+            return
+
+        r, c = move_index // self.size, move_index % self.size
+        self.board[r, c] = player
+
+        captured_stones_count_this_move = 0
+        captured_single_stone_location: Optional[Tuple[int,int]] = None
+
+        # Capture logic
+        opponent = -player
+        for dr, dc in [(0, 1), (0, -1), (1, 0), (-1, 0)]:
+            nr, nc = r + dr, c + dc
+            if 0 <= nr < self.size and 0 <= nc < self.size and self.board[nr, nc] == opponent:
+                group_stones, group_liberties = self._get_group(nr, nc)
+                if not group_liberties: # No liberties, group is captured
+                    if len(group_stones) == 1:
+                        captured_single_stone_location = list(group_stones)[0]
+
+                    for stone_r, stone_c in group_stones:
+                        self.board[stone_r, stone_c] = 0
+                        captured_stones_count_this_move += 1
+
+        if captured_stones_count_this_move > 0:
+            self.captured_stones[player] += captured_stones_count_this_move
+
+        # Ko update
+        if captured_stones_count_this_move == 1 and captured_single_stone_location is not None:
+            # Check if the placed stone has only one liberty and that liberty is the captured stone's location
+            # This means the stone just placed at (r,c) is now part of a group.
+            # We need the liberties of the group containing (r,c)
+            played_stone_group, played_stone_liberties = self._get_group(r,c)
+            if len(played_stone_liberties) == 1:
+                single_liberty_loc = list(played_stone_liberties)[0]
+                if single_liberty_loc == captured_single_stone_location:
+                    # Check if playing at captured_single_stone_location by opponent would be suicide
+                    # (i.e. it would have 0 liberties itself without capturing the stone at (r,c))
+                    # This is a simplified ko rule. A more precise one might check if the board state reverts.
+                    self.ko_point = captured_single_stone_location[0] * self.size + captured_single_stone_location[1]
+        # else: # self.ko_point is already None if not a ko
+
+        self.history.append((player, move_index))
+        self.to_play *= -1
+
+    def get_board_state(self) -> torch.Tensor:
+        """
+        Returns a copy of the current board state.
+        """
+        return self.board.clone()
+
+    def copy(self) -> 'GoBoard':
+        """
+        Creates a deep copy of the current board state.
+        """
+        new_board = GoBoard(self.size)
+        new_board.board = self.board.clone()
+        new_board.to_play = self.to_play
+        new_board.history = self.history[:] # Shallow copy of list of tuples is fine
+        new_board.ko_point = self.ko_point
+        new_board.captured_stones = self.captured_stones.copy()
+        new_board.komi = self.komi # Copy komi
+        # PASS_MOVE is set by __init__ based on size, so no need to copy explicitly
+        return new_board
+
+    def legal_moves(self) -> List[int]:
+        """
+        Returns a list of all legal move indices for the current player.
+        Includes the pass move.
+        """
+        moves = []
+        for i in range(self.size * self.size): # Board points
+            if self.is_legal_move(i):
+                moves.append(i)
+        if self.is_legal_move(self.PASS_MOVE): # Pass move
+            moves.append(self.PASS_MOVE)
+        return moves
+
+    def __str__(self) -> str:
+        chars = {0: '.', 1: 'X', -1: 'O'}
+        s = f"To play: {chars[self.to_play]} (Black: {self.captured_stones[1]}, White: {self.captured_stones[-1]}) Komi: {self.komi}\n"
+        s += "  " + " ".join([chr(ord('A') + i + (i >= 8)) for i in range(self.size)]) + "\n" # Skip 'I'
+        for r in range(self.size):
+            s += f"{self.size - r:2d} " + " ".join([chars[self.board[r, c].item()] for c in range(self.size)]) + "\n"
+        if self.ko_point is not None:
+            kr, kc = self.ko_point // self.size, self.ko_point % self.size
+            ko_char_col = chr(ord('A') + kc + (kc >= 8)) # Skip 'I'
+            s += f"Ko point: ({ko_char_col}{self.size-kr})\n"
+        return s
+
+if __name__ == '__main__':
+    # Example Usage (for testing during development)
+    board = GoBoard(5)
+    print(board)
+
+    # B plays C3 (index for 5x5: (5-3)*5 + 2 = 2*5 + 2 = 12)
+    # A B C D E
+    # 5 . . . . .
+    # 4 . . . . .
+    # 3 . . X . .  (X is at (2,2) in 0-indexed tensor)
+    # 2 . . . . .
+    # 1 . . . . .
+    # board.play_move(2*5 + 2) # B at C3
+    # print(board)
+    #
+    # # W plays C4 (index for 5x5: (5-4)*5 + 2 = 1*5 + 2 = 7)
+    # # A B C D E
+    # # 5 . . . . .
+    # # 4 . . O . .  (O is at (1,2) in 0-indexed tensor)
+    # # 3 . . X . .
+    # # 2 . . . . .
+    # # 1 . . . . .
+    # board.play_move(1*5 + 2) # W at C4
+    # print(board)
+
+    # Test basic capture
+    # B: D3 (2,3), W: C3 (2,2), B: D2 (3,3), W: E3 (2,4), B: C2 (3,2), W: D4 (1,3), B: E2 (3,4)
+    # W plays D3 (2,3), capturing nothing
+    # B plays C3 (2,2)
+    # W plays D2 (3,3)
+    # B plays E3 (2,4)
+    # W plays C2 (3,2)
+    # B plays D4 (1,3)
+    # W plays E2 (3,4)
+    # B plays D3 (2,3) to capture C3, D2, E3, C2, D4, E2
+    # This setup is for a 9x9 board typically. Let's try a simpler 5x5 capture.
+    # . . . . .
+    # . O X . .  X at (1,2), O at (1,1)
+    # . X . . .  X at (2,1)
+    # . . . . .
+    # . . . . .
+    # Black plays (1,1) to capture (1,2)
+    # board = GoBoard(5)
+    # board.play_move(1*5+2) # B at (1,2) - C4
+    # print(board)
+    # board.play_move(2*5+1) # W at (2,1) - B3
+    # print(board)
+    # board.play_move(1*5+1) # B at (1,1) - B4, to capture (1,2)
+    # print(board) # This move is suicide without capture, should be illegal if suicide rule is on
+    # board.play_move(0*5+2) # W at (0,2) - C5
+    # print(board)
+    # board.play_move(2*5+2) # B at (2,2) - C3
+    # print(board)
+    # # Now board is:
+    # # . . O . . (0,2) W
+    # # . X X . . (1,1) B, (1,2) B
+    # # . O X . . (2,1) W, (2,2) B
+    # # If W plays (1,0) (A4), it should capture (1,1)B
+    # board.play_move(1*5+0) # W at (1,0)
+    # print(board)
+    # print(f"Captured by White: {board.captured_stones[-1]}")
+    # print(f"Captured by Black: {board.captured_stones[1]}")
+
+    # Test Ko
+    # . . . . .
+    # . X O . .  X at (1,1), O at (1,2)
+    # X O . . .  X at (2,0), O at (2,1)
+    # . . . . .
+    g = GoBoard(5)
+    g.play_move(g.coords_to_idx(1,1)) # B plays (1,1) (B4)
+    g.play_move(g.coords_to_idx(1,2)) # W plays (1,2) (C4)
+    g.play_move(g.coords_to_idx(2,0)) # B plays (2,0) (A3)
+    g.play_move(g.coords_to_idx(2,1)) # W plays (2,1) (B3)
+    print(g)
+    # Current board:
+    # . . . . .
+    # . X O . .
+    # X O . . .
+    # . . . . .
+    # B plays (2,2) C3. This should capture (1,2)O and (2,1)O if set up like this
+    # Let's make a simpler ko:
+    # . O X .
+    # O X . X
+    # . O X .
+    # . . . .
+    # B plays X at (0,2). W plays O at (0,1)
+    # B plays X at (1,1). W plays O at (1,0)
+    # B plays X at (2,2). W plays O at (2,1)
+    # B plays X at (1,3)
+
+    # Setup for Ko:
+    #   A B C D
+    # 4 . O X .   (0,1) (0,2)
+    # 3 O X . .   (1,0) (1,1)
+    # 2 . O . .   (2,1)
+    # 1 . . . .
+    board = GoBoard(4)
+    # Helper for tests
+    def c2i(r,c,s=board.size): return r*s+c
+    board.to_play=1 #B
+    board.play_move(c2i(0,2)) # B X at (0,2)
+    board.play_move(c2i(0,1)) # W O at (0,1)
+    board.play_move(c2i(1,1)) # B X at (1,1)
+    board.play_move(c2i(1,0)) # W O at (1,0)
+    board.play_move(c2i(2,1)) # B X at (2,1) -> This should be B, Mistake in manual trace, should be W
+    # Corrected Ko setup:
+    #   A B C D E
+    # 5 . . . . .
+    # 4 . X O . .  (B4, C4)
+    # 3 X O . . .  (A3, B3)
+    # 2 . X O . .  (B2, C2)
+    # 1 . . . . .
+    # B plays B4 (1,1), W plays C4 (1,2)
+    # B plays A3 (2,0), W plays B3 (2,1)
+    # B plays B2 (3,1), W plays C2 (3,2)
+    # B plays C3 (2,2) - captures B3(O at 2,1)
+    # W plays B3 (2,1) - captures C3(X at 2,2) -> KO
+
+    ko_board = GoBoard(size=5)
+    ko_board.play_move(ko_board.coords_to_idx(1,1)) # B: B4
+    ko_board.play_move(ko_board.coords_to_idx(1,2)) # W: C4
+    ko_board.play_move(ko_board.coords_to_idx(2,0)) # B: A3
+    ko_board.play_move(ko_board.coords_to_idx(2,1)) # W: B3 (O)
+    ko_board.play_move(ko_board.coords_to_idx(3,1)) # B: B2
+    ko_board.play_move(ko_board.coords_to_idx(3,2)) # W: C2
+    print("Initial Ko Setup:")
+    print(ko_board)
+    # B plays C3 (idx 2,2 for 5x5 is 2*5+2=12)
+    # This captures W's stone at B3 (idx 2,1 for 5x5 is 2*5+1=11)
+    print("B plays C3 (2,2), capturing W at B3 (2,1)")
+    ko_board.play_move(ko_board.coords_to_idx(2,2)) # B: C3
+    print(ko_board)
+    print(f"Ko point: {ko_board.ko_point} (should be index of B3: {ko_board.coords_to_idx(2,1)})")
+
+    print(f"Is W playing B3 (2,1) legal? {ko_board.is_legal_move(ko_board.coords_to_idx(2,1))}") # Should be False (Ko)
+
+    # Make a non-ko move for W
+    print("W makes a non-ko move (A5)")
+    ko_board.play_move(ko_board.coords_to_idx(0,0)) # W: A5
+    print(ko_board)
+    print(f"Ko point: {ko_board.ko_point} (should be None)")
+    print(f"Is B playing B3 (2,1) legal now? {ko_board.is_legal_move(ko_board.coords_to_idx(2,1))}") # Should be True
+
+
+    # Add a coords_to_idx helper to GoBoard for easier testing
+    def coords_to_idx(self, r, c):
+        return r * self.size + c
+    GoBoard.coords_to_idx = coords_to_idx
+
+    # Test Suicide
+    # . . . . .
+    # . X . . . (1,1) B
+    # X O X . . (2,0) B, (2,1) W, (2,2) B
+    # . X . . . (3,1) B
+    # . . . . .
+    # W tries to play at (2,1) - this is suicide
+    suicide_board = GoBoard(5)
+    suicide_board.play_move(suicide_board.coords_to_idx(1,1)) # B
+    suicide_board.play_move(suicide_board.coords_to_idx(0,0)) # W dummy
+    suicide_board.play_move(suicide_board.coords_to_idx(2,0)) # B
+    suicide_board.play_move(suicide_board.coords_to_idx(0,1)) # W dummy
+    suicide_board.play_move(suicide_board.coords_to_idx(2,2)) # B
+    suicide_board.play_move(suicide_board.coords_to_idx(0,2)) # W dummy
+    suicide_board.play_move(suicide_board.coords_to_idx(3,1)) # B
+    print("Suicide Test Setup:")
+    print(suicide_board) # W to play
+
+    # W tries to play at (2,1)
+    suicide_move_idx = suicide_board.coords_to_idx(2,1)
+    print(f"Is W playing at (2,1) (idx {suicide_move_idx}) legal? {suicide_board.is_legal_move(suicide_move_idx)}") # Should be False
+
+    # Test suicide that captures (not suicide)
+    # . O . . . (0,1) W
+    # O X O . . (1,0) W, (1,1) B, (1,2) W
+    # . O . . . (2,1) W
+    # . . . . .
+    # B plays at (1,1) - this would be suicide, but it captures the surrounding Os
+    cap_suicide_board = GoBoard(5)
+    cap_suicide_board.to_play = -1 # W starts
+    cap_suicide_board.play_move(cap_suicide_board.coords_to_idx(0,1)) #W
+    cap_suicide_board.play_move(cap_suicide_board.coords_to_idx(0,0)) #B dummy
+    cap_suicide_board.play_move(cap_suicide_board.coords_to_idx(1,0)) #W
+    cap_suicide_board.play_move(cap_suicide_board.coords_to_idx(0,2)) #B dummy
+    cap_suicide_board.play_move(cap_suicide_board.coords_to_idx(1,2)) #W
+    cap_suicide_board.play_move(cap_suicide_board.coords_to_idx(0,3)) #B dummy
+    cap_suicide_board.play_move(cap_suicide_board.coords_to_idx(2,1)) #W
+    print("Capture-Suicide Test Setup:")
+    print(cap_suicide_board) # B to play
+
+    # B plays at (1,1)
+    cap_suicide_move_idx = cap_suicide_board.coords_to_idx(1,1)
+    print(f"Is B playing at (1,1) (idx {cap_suicide_move_idx}) legal? {cap_suicide_board.is_legal_move(cap_suicide_move_idx)}") # Should be True
+    if cap_suicide_board.is_legal_move(cap_suicide_move_idx):
+        cap_suicide_board.play_move(cap_suicide_move_idx)
+        print("Board after B plays at (1,1):")
+        print(cap_suicide_board)
+        print(f"Captured by Black: {cap_suicide_board.captured_stones[1]}")
+
+```

--- a/features.py
+++ b/features.py
@@ -1,0 +1,275 @@
+import torch
+from board import GoBoard # Assuming board.py is in the same directory or accessible
+from typing import Set, Tuple, List, Dict, Optional
+
+def extract_katago_features(board: GoBoard, model_channels: int) -> torch.Tensor:
+    """
+    Extracts spatial features from a GoBoard state, similar to KataGo's input representation.
+
+    Args:
+        board (GoBoard): The current Go board state.
+        model_channels (int): The number of expected input channels for the KataGo model.
+
+    Returns:
+        torch.Tensor: A tensor of shape (1, model_channels, board.size, board.size).
+    """
+    if not isinstance(board, GoBoard):
+        raise ValueError("Input 'board' must be an instance of GoBoard.")
+    if not isinstance(model_channels, int) or model_channels <= 0:
+        raise ValueError("model_channels must be a positive integer.")
+
+    size = board.size
+    features = torch.zeros((1, model_channels, size, size), dtype=torch.float32)
+
+    current_player_color = board.to_play
+    opponent_color = -board.to_play
+
+    # --- Base Features (Planes 0, 1, 2) ---
+    # Plane 0: Player Stones
+    if model_channels > 0:
+        features[0, 0, :, :] = (board.board == current_player_color).float()
+
+    # Plane 1: Opponent Stones
+    if model_channels > 1:
+        features[0, 1, :, :] = (board.board == opponent_color).float()
+
+    # Plane 2: Empty Points
+    if model_channels > 2:
+        features[0, 2, :, :] = (board.board == 0).float()
+
+    # --- Liberty-based Features (Planes 3-10 for player, 11-18 for opponent) ---
+    # Max 8 planes for liberties (1 to 7, and 8+)
+    # Player liberties: channels 3 to 10
+    # Opponent liberties: channels 11 to 18
+
+    # Iterate through each point on the board once to calculate liberties
+    # This is more efficient than calling board.count_liberties() for each stone repeatedly
+    # However, board.count_liberties itself uses _get_group, which finds all stones in a group.
+    # To avoid redundant _get_group calls for stones in the same group, we can cache group liberties.
+
+    # For simplicity in this first pass, we will call count_liberties per stone.
+    # Optimization can be added later if performance is an issue.
+
+    for r in range(size):
+        for c in range(size):
+            stone_color = board.board[r, c].item()
+
+            if stone_color == current_player_color:
+                libs = board.count_liberties(r, c)
+                # Player liberty planes start at index 3
+                # min(libs, 8) -> 1 to 8. To map to planes 3 to 10: (2 + min(libs,8))
+                # libs = 1 -> plane 3 (2+1)
+                # libs = 8 -> plane 10 (2+8)
+                if libs > 0: # only mark if there are liberties (stone exists)
+                    lib_plane_idx = 2 + min(libs, 8)
+                    if model_channels > lib_plane_idx:
+                        features[0, lib_plane_idx, r, c] = 1.0
+
+            elif stone_color == opponent_color:
+                libs = board.count_liberties(r, c)
+                # Opponent liberty planes start at index 11 (3 + 8)
+                # min(libs, 8) -> 1 to 8. To map to planes 11 to 18: (10 + min(libs,8))
+                # libs = 1 -> plane 11 (10+1)
+                # libs = 8 -> plane 18 (10+8)
+                if libs > 0: # only mark if there are liberties (stone exists)
+                    lib_plane_idx = 10 + min(libs, 8)
+                    if model_channels > lib_plane_idx:
+                        features[0, lib_plane_idx, r, c] = 1.0
+
+    # --- Ko Point (Plane 19) ---
+    # Current channel count used: 3 (base) + 8 (player_lib) + 8 (opp_lib) = 19
+    ko_plane_idx = 19
+    if model_channels > ko_plane_idx and board.ko_point is not None:
+        ko_r, ko_c = board.ko_point // size, board.ko_point % size
+        features[0, ko_plane_idx, ko_r, ko_c] = 1.0
+
+    # --- Last Move Location (Plane 20) ---
+    last_move_plane_idx = 20
+    if model_channels > last_move_plane_idx and board.history:
+        last_player, last_move_idx = board.history[-1]
+        if last_move_idx != board.PASS_MOVE:
+            last_r, last_c = last_move_idx // size, last_move_idx % size
+            features[0, last_move_plane_idx, last_r, last_c] = 1.0
+
+    # --- Player to Play Plane (Plane 21) ---
+    # Indicates whose turn it is. Filled with 1.0 if current player is Black, -1.0 if White.
+    # Or 1.0 for current player, 0.0 for other schemes. KataGo typically uses 0s and 1s.
+    # Let's use a single plane: 1.0 if Black to play, 0.0 if White to play (as per some interpretations)
+    # Or, more directly, fill plane with board.to_play (1.0 for black, -1.0 for white)
+    player_to_play_plane_idx = 21
+    if model_channels > player_to_play_plane_idx:
+        # features[0, player_to_play_plane_idx, :, :] = float(board.to_play)
+        # KataGo often uses binary indicators. Let's use two planes if budget allows or one if not.
+        # For now, let's use a single plane indicating the current player's color (1.0 or -1.0).
+        # This matches the "sense of color" features in some models.
+        features[0, player_to_play_plane_idx, :, :] = float(board.to_play)
+
+
+    # --- Additional History Planes (Example: up to last 5 moves) ---
+    # Example: Plane 22 for 2nd to last move, Plane 23 for 3rd, etc.
+    # Requires model_channels > 22, > 23, etc.
+    # Start history planes from channel `base_history_idx`. Last move is already at `last_move_plane_idx`.
+    # Let's refine this for multiple history moves if channels allow.
+    # If last_move_plane_idx is 20.
+    # history_planes_start_idx = 20 (for current player's last move)
+    # history_planes_opponent_start_idx = history_planes_start_idx + num_history_planes_per_player
+
+    # Simplified: Last N moves, regardless of player.
+    # Plane 20 = last move (already done)
+    # Plane 22 = 2nd to last move (if model_channels > 22)
+    # Plane 23 = 3rd to last move (if model_channels > 23)
+    # ...
+    # This is a simple linear history. KataGo's history features are more complex (e.g. N recent moves by current player, N recent moves by opponent)
+    # For now, let's stick to the single "last move" at plane 20.
+    # If more history planes were to be added, the logic would be:
+    # current_history_plane = last_move_plane_idx # 20
+    # for i, (player, move_idx) in enumerate(reversed(board.history)):
+    #     if i == 0: # Already handled by last_move_plane_idx
+    #         continue
+    #     target_plane = some_base_index_for_further_history + i -1
+    #     if model_channels > target_plane and move_idx != board.PASS_MOVE:
+    #          move_r, move_c = move_idx // size, move_idx % size
+    #          features[0, target_plane, move_r, move_c] = 1.0
+    #     if target_plane >= model_channels -1 : break # stop if no more channels
+
+    # All other planes will remain zero if not explicitly filled.
+    return features
+
+if __name__ == '__main__':
+    # Basic test
+    from board import GoBoard
+
+    test_board = GoBoard(19)
+    # Play some moves
+    # B: D4 (3,3) -> (19-4)*19+3 = 15*19+3 = 285+3 = 288
+    # W: Q16 (15,15) -> (19-16)*19+15 = 3*19+15 = 57+15 = 72
+    # B: Pass
+    # W: K10 (9,9) -> (19-10)*19+9 = 9*19+9 = 171+9 = 180 (ko point for example)
+
+    print("Creating board and playing some moves...")
+    # Helper for tests
+    def c2i(r_chess, c_char, s=test_board.size):
+        # r_chess is 1-indexed from bottom, c_char is 'A'-'T' (skipping 'I')
+        col_idx = ord(c_char.upper()) - ord('A')
+        if col_idx >= 8: # 'I' is skipped
+            col_idx -=1
+        row_idx = s - r_chess # 0-indexed from top
+        return row_idx * s + col_idx
+
+    # test_board.play_move(c2i(4, 'D')) # B at D4 (r=15,c=3 in 0-indexed from top)
+    # test_board.play_move(c2i(16, 'Q'))# W at Q16 (r=3,c=15)
+    # test_board.play_move(test_board.PASS_MOVE) # B Pass
+    # test_board.ko_point = c2i(10,'K') # W K10 (r=9,c=9) - set manually for testing ko plane
+    # test_board.play_move(c2i(10,'K')) # W K10 - this would be illegal if ko rule applied before this play
+
+    # Simpler setup for testing specific features
+    b = GoBoard(5)
+    # (0,0) B, (0,1) W, (1,0) B with 1 liberty
+    # (2,2) B, (2,3) W, (3,2) B, (3,3) W - W at (3,3) has 2 libs
+    # (4,4) B - pass - W to play, (4,4) is last move
+    # Ko at (0,2)
+
+    b.play_move(b.coords_to_idx(0,0)) # B
+    b.play_move(b.coords_to_idx(0,1)) # W
+    b.play_move(b.coords_to_idx(1,0)) # B - stone (0,0) has 2 libs, (1,0) has 2 libs
+                                     # W stone (0,1) has 2 libs
+
+    # Check stone (0,0) for B (current player is W, so B is opponent)
+    # (0,0) is opponent, libs = 2. Plane 10 + 2 = 12
+
+    b.play_move(b.coords_to_idx(2,2)) # W
+    b.play_move(b.coords_to_idx(2,3)) # B
+    b.play_move(b.coords_to_idx(3,2)) # W
+    b.play_move(b.coords_to_idx(3,3)) # B - stone (3,3) has 2 libs. Current player W. (3,3) is opponent. Plane 10+2=12
+                                     # stone (2,3) B has 3 libs.
+                                     # stone (2,2) W has 3 libs. Plane 2+3 = 5
+                                     # stone (3,2) W has 3 libs. Plane 2+3 = 5
+
+    # B plays pass
+    b.play_move(b.PASS_MOVE) # B plays pass, W to play. Last move was pass.
+
+    # W plays (4,4)
+    b.play_move(b.coords_to_idx(4,4)) # W plays (4,4). B to play. Last move (4,4) by W.
+
+    b.ko_point = b.coords_to_idx(0,2) # Manually set ko point for testing
+
+    print("\nBoard state:")
+    print(b) # B to play
+
+    print(f"\nTesting with model_channels = 22")
+    features_22 = extract_katago_features(b, 22)
+    print(f"Output shape: {features_22.shape}")
+
+    # Player is Black (1)
+    # Opponent is White (-1)
+
+    # Plane 0: Player Stones (Black)
+    print(f"\nPlayer (Black) stones (Plane 0):")
+    print(features_22[0,0,:,:])
+    # Expected: (0,0)B, (1,0)B, (2,3)B, (3,3)B
+
+    # Plane 1: Opponent Stones (White)
+    print(f"\nOpponent (White) stones (Plane 1):")
+    print(features_22[0,1,:,:])
+    # Expected: (0,1)W, (2,2)W, (3,2)W, (4,4)W
+
+    # Plane 2: Empty
+    print(f"\nEmpty points (Plane 2):")
+    print(features_22[0,2,:,:])
+
+    # Player (Black) stone liberties
+    # (0,0)B has 2 libs (adj to (0,1)W, (1,0)B). Libs at (1,1), (0,2) if empty...
+    # Let's re-verify with current board:
+    # B . O . .  (0,0)B, (0,1)W. (0,0)B has libs at (1,0)-B and empty (0,2) if ko is not there.
+    # X . . . .  (1,0)B.
+    # . . W B .  (2,2)W, (2,3)B
+    # . . W B .  (3,2)W, (3,3)B
+    # . . . . O  (4,4)W
+    # B to play. Ko at (0,2)
+    # Player (B) stones:
+    # (0,0)B: libs at (1,1) (empty), (0,2) (empty, but ko). So 1 actual liberty?
+    #   _get_group for (0,0)B: stones={(0,0),(1,0)}, libs={(1,1),(0,2),(2,0)}. Count = 3. Plane 2+3 = 5.
+    # (1,0)B: same group. Plane 5.
+    # (2,3)B: libs at (1,3),(2,4),(3,3)-B,(1,2). Count = 3. Plane 5.
+    # (3,3)B: same group. Plane 5.
+    print(f"\nPlayer (Black) stone with 3 libs (Plane 5 = 2+3):")
+    print(features_22[0, 5, :, :])
+
+
+    # Opponent (White) stone liberties
+    # (0,1)W: libs at (0,0)-B,(1,1),(0,2)-ko. Count = 2. Plane 10+2 = 12.
+    # (2,2)W: libs at (1,2),(2,1),(3,2)-W,(1,3). Count = 3. Plane 10+3 = 13.
+    # (3,2)W: same group. Plane 13.
+    # (4,4)W: libs at (3,4),(4,3). Count = 2. Plane 12.
+    print(f"\nOpponent (White) stone with 2 libs (Plane 12 = 10+2):")
+    print(features_22[0, 12, :, :])
+    print(f"\nOpponent (White) stone with 3 libs (Plane 13 = 10+3):")
+    print(features_22[0, 13, :, :])
+
+
+    # Plane 19: Ko point
+    print(f"\nKo point (Plane 19) at (0,2):")
+    print(features_22[0, 19, :, :]) # Expected: 1.0 at (0,2)
+
+    # Plane 20: Last move location
+    # Last actual move was (4,4) by W.
+    print(f"\nLast move (Plane 20) at (4,4):")
+    print(features_22[0, 20, :, :]) # Expected: 1.0 at (4,4)
+
+    # Plane 21: Player to Play Plane
+    # B to play, so value should be 1.0
+    print(f"\nPlayer to Play (Plane 21), B to play (all 1.0):")
+    print(features_22[0, 21, :, :])
+
+    print(f"\nTesting with model_channels = 3")
+    features_3 = extract_katago_features(b, 3)
+    print(f"Output shape: {features_3.shape}")
+    assert features_3[0,0,0,0].item() == 1.0 # Player stone B at (0,0)
+    assert features_3[0,1,0,1].item() == 1.0 # Opponent stone W at (0,1)
+    assert features_3[0,2,0,3].item() == 1.0 # Empty at (0,3)
+    if model_channels > 3: # Check that other channels are zero
+      if features_3.shape[1] > 3:
+        assert torch.all(features_3[0,3,:,:] == 0)
+
+    print("\nBasic tests completed.")
+```

--- a/gtp_engine.py
+++ b/gtp_engine.py
@@ -22,7 +22,9 @@ import time
 
 import torch
 
-from mcts import MCTS, MinimalGoBoard, ModelConfig, KataGoModel
+from mcts import MCTS # MinimalGoBoard is removed from mcts.py
+from model import ModelConfig, KataGoModel
+from board import GoBoard # Import GoBoard
 
 
 LETTERS = "ABCDEFGHJKLMNOPQRST"
@@ -62,10 +64,26 @@ def index_to_coord(idx: int, size: int) -> str:
 class GtpEngine:
     def __init__(self, mcts: MCTS):
         self.mcts = mcts
-        self.board = MinimalGoBoard(mcts.config.board_size)
-        self.mask = torch.ones(
-            mcts.config.board_size, mcts.config.board_size, dtype=torch.float32
-        )
+        self.komi: float = 7.5 # Default komi for the engine
+        # Use GoBoard, mcts.config.board_size should be from ModelConfig
+        self.board = GoBoard(mcts.config.board_size)
+        self.board.komi = self.komi # Ensure new board gets engine's komi
+        # self.mask is no longer needed
+        self.implemented_commands = {
+            "protocol_version",
+            "name",
+            "version",
+            "clear_board",
+            "boardsize",
+            "play",
+            "genmove",
+            "quit",
+            "set_param",
+            "known_command",
+            "list_commands",
+            "komi",
+            "get_komi"
+        }
 
     # Utility responses --------------------------------------------------
     def respond(self, msg: str = "") -> None:
@@ -83,43 +101,58 @@ class GtpEngine:
         except ValueError:
             self.error("invalid vertex")
             return
-        if color.lower().startswith("b"):
-            expected = 1
-        else:
-            expected = -1
-        if self.board.to_play != expected:
-            self.board.to_play = expected
-        if idx != self.board.size * self.board.size:
-            x = idx % self.board.size
-            y = idx // self.board.size
-            if self.board.board[y, x] != 0:
-                self.error("illegal move")
-                return
-        self.board.play(idx)
-        self.respond()
+        # Set player turn correctly in GoBoard
+        player_to_set = 1 if color.lower().startswith("b") else -1
+        if self.board.to_play != player_to_set:
+            self.board.to_play = player_to_set # Force turn if GTP says so, though ideally it matches
+
+        try:
+            # GoBoard.play_move will check legality (occupation, ko, suicide)
+            self.board.play_move(idx)
+            self.respond()
+        except ValueError as e:
+            self.error(f"illegal move: {e}")
 
     def handle_genmove(self, color: str) -> None:
-        if color.lower().startswith("b"):
-            self.board.to_play = 1
-        else:
-            self.board.to_play = -1
+        # Set player turn correctly in GoBoard
+        player_to_set = 1 if color.lower().startswith("b") else -1
+        if self.board.to_play != player_to_set:
+             self.board.to_play = player_to_set # Ensure MCTS searches for the correct player
+
         start = time.time()
-        best = self.mcts.search(self.board, self.mask)
+        # MCTS search no longer takes a mask
+        best_move = self.mcts.search(self.board)
         elapsed = time.time() - start
-        print(f"# PLAYOUTS: {elapsed:.2f}s", file=sys.stderr)
-        vertex = index_to_coord(best, self.board.size)
-        self.board.play(best)
-        self.respond(vertex)
+        print(f"# PLAYOUTS: {elapsed:.2f}s ({self.mcts.n_playouts} playouts)", file=sys.stderr)
+
+        try:
+            vertex = index_to_coord(best_move, self.board.size)
+            self.board.play_move(best_move) # Play the best move on our GoBoard
+            self.respond(vertex)
+        except ValueError as e: # Should not happen if MCTS returns valid move
+            self.error(f"MCTS generated an illegal move: {best_move}, error: {e}")
+        except Exception as e: # Catch any other unexpected errors
+            self.error(f"Error processing MCTS move: {e}")
+
 
     def handle_boardsize(self, size: str) -> None:
         try:
             s = int(size)
+            if s <= 0: # Basic validation for board size
+                self.error("invalid boardsize: must be positive")
+                return
         except ValueError:
-            self.error("invalid boardsize")
+            self.error("invalid boardsize: not an integer")
             return
-        self.board = MinimalGoBoard(s)
-        self.mask = torch.ones(s, s, dtype=torch.float32)
-        self.mcts.config.board_size = s
+
+
+        if s != self.mcts.config.board_size:
+            self.error(f"board size {s}x{s} not supported, current model is {self.mcts.config.board_size}x{self.mcts.config.board_size}")
+            return
+
+        # If s is the same as current model config size, effectively clear_board
+        self.board = GoBoard(s)
+        self.board.komi = self.komi # Ensure new board gets engine's komi
         self.respond()
 
     def handle_set_param(self, name: str, value: str) -> None:
@@ -151,7 +184,9 @@ class GtpEngine:
         elif cmd == "version":
             self.respond("0.1")
         elif cmd == "clear_board":
-            self.board = MinimalGoBoard(self.board.size)
+            # Reinitialize GoBoard using the model's configured board size
+            self.board = GoBoard(self.mcts.config.board_size)
+            self.board.komi = self.komi # Apply current engine komi
             self.respond()
         elif cmd == "boardsize" and len(args) == 1:
             self.handle_boardsize(args[0])
@@ -161,15 +196,44 @@ class GtpEngine:
             self.handle_genmove(args[0])
         elif cmd == "set_param" and len(args) == 2:
             self.handle_set_param(args[0], args[1])
+        elif cmd == "known_command":
+            if len(args) == 1:
+                if args[0] in self.implemented_commands:
+                    self.respond("true")
+                else:
+                    self.respond("false")
+            else:
+                self.error("wrong number of arguments")
+        elif cmd == "list_commands":
+            if len(args) == 0:
+                self.respond("\n".join(sorted(list(self.implemented_commands))))
+            else:
+                self.error("wrong number of arguments")
+        elif cmd == "komi":
+            if len(args) == 1:
+                try:
+                    new_komi = float(args[0])
+                    self.komi = new_komi
+                    self.board.komi = self.komi # Update board's komi as well
+                    self.respond()
+                except ValueError:
+                    self.error("invalid komi value")
+            else:
+                self.error("wrong number of arguments")
+        elif cmd == "get_komi":
+            if len(args) == 0:
+                self.respond(str(self.komi))
+            else:
+                self.error("wrong number of arguments")
         else:
             self.error("unknown command")
         return True
 
 
 def main() -> None:
-    config = ModelConfig()
+    config = ModelConfig()  # Use default config for internal model
     model = KataGoModel(config)
-    mcts = MCTS(model, config)
+    mcts = MCTS(model, config) # Pass internal model and config
     engine = GtpEngine(mcts)
     while True:
         try:

--- a/mcts.py
+++ b/mcts.py
@@ -1,69 +1,14 @@
 from __future__ import annotations
 
 import math
-from dataclasses import dataclass
-from typing import Dict, Optional
+from dataclasses import dataclass, field
+from typing import Dict, Optional, List
 
 import torch
 
 from model import KataGoModel, ModelConfig
-
-
-class MinimalGoBoard:
-    """A tiny Go board representation for testing MCTS.
-
-    Parameters
-    ----------
-    size : int
-        Board width/height. Only square boards are supported.
-    """
-
-    def __init__(self, size: int = 19):
-        self.size = size
-        self.board = torch.zeros(size, size, dtype=torch.int8)
-        self.to_play = 1  # 1 for black, -1 for white
-        self.passes = 0
-
-    def copy(self) -> "MinimalGoBoard":
-        new = MinimalGoBoard(self.size)
-        new.board = self.board.clone()
-        new.to_play = self.to_play
-        new.passes = self.passes
-        return new
-
-    def legal_moves(self):
-        moves = [i for i in range(self.size * self.size) if self.board.view(-1)[i] == 0]
-        moves.append(self.size * self.size)  # pass
-        return moves
-
-    def play(self, move: int) -> None:
-        if move == self.size * self.size:
-            self.passes += 1
-        else:
-            self.passes = 0
-            x = move % self.size
-            y = move // self.size
-            self.board[y, x] = self.to_play
-        self.to_play *= -1
-
-    def is_terminal(self) -> bool:
-        return self.passes >= 2 or (self.board != 0).all()
-
-
-def extract_features(board: MinimalGoBoard) -> torch.Tensor:
-    """Return a simple feature tensor for ``board``.
-
-    The tensor has shape ``(1, 28, S, S)`` and encodes black/white stones
-    and the player to move.
-    """
-
-    size = board.size
-    feats = torch.zeros(1, 28, size, size, dtype=torch.float32)
-    feats[0, 0] = (board.board == 1).float()
-    feats[0, 1] = (board.board == -1).float()
-    if board.to_play == 1:
-        feats[0, 2].fill_(1.0)
-    return feats
+from board import GoBoard # Use the new GoBoard
+from features import extract_katago_features # Use the new feature extraction
 
 
 @dataclass
@@ -72,35 +17,30 @@ class MCTSNode:
 
     Attributes
     ----------
-    board : MinimalGoBoard
+    board : GoBoard # Changed from MinimalGoBoard
         Board position represented by this node.
     parent : Optional[MCTSNode]
         Link to parent node or ``None`` if root.
-    children : Dict[int, MCTSNode]
+    children : Dict[int, MCTSNode] = field(default_factory=dict)
         Mapping of action index to child nodes.
-    N : int
+    N : int = 0
         Visit count.
-    W : float
+    W : float = 0.0
         Total value accumulated through simulations.
-    P : float
-        Prior probability from the policy network.
+    P : float = 1.0 # Prior probability for the action *leading* to this node's state
+        Prior probability from the policy network for the move that led to this state.
     """
 
-    board: MinimalGoBoard
+    board: GoBoard
     parent: Optional["MCTSNode"] = None
-    children: Dict[int, "MCTSNode"] = None
+    children: Dict[int, "MCTSNode"] = field(default_factory=dict)
     N: int = 0
     W: float = 0.0
     P: float = 1.0
 
-    def __post_init__(self):
-        if self.children is None:
-            self.children = {}
-        self.features: Optional[torch.Tensor] = None
-
 
 class MCTS:
-    """Simplified UCT Monte Carlo Tree Search using :class:`KataGoModel`.
+    """Simplified UCT Monte Carlo Tree Search using :class:`KataGoModel` and :class:`GoBoard`.
 
     Parameters
     ----------
@@ -126,71 +66,279 @@ class MCTS:
 
     def _uct_select(self, node: MCTSNode) -> MCTSNode:
         """Select a child with maximum UCT score."""
+        if not node.children: # Should not happen if called correctly
+            raise ValueError("Cannot select from a node with no children.")
 
-        actions = list(node.children.keys())
-        children = list(node.children.values())
-        N = torch.tensor([c.N for c in children], dtype=torch.float32)
-        W = torch.tensor([c.W for c in children], dtype=torch.float32)
-        P = torch.tensor([c.P for c in children], dtype=torch.float32)
-        Q = torch.where(N > 0, W / N, torch.zeros_like(W))
-        U = self.c_puct * P * math.sqrt(max(node.N, 1)) / (1 + N)
-        idx = torch.argmax(Q + U).item()
-        return children[idx]
+        # actions = list(node.children.keys()) # Redundant, children values are MCTSNode instances
+        children_nodes = list(node.children.values())
 
-    def search(self, board: MinimalGoBoard, mask: torch.Tensor) -> int:
+        # Calculate N, W, P for each child
+        # N_parent is node.N (visit count of current node)
+        # N_child is child.N (visit count of child node)
+        # W_child is child.W (total value from child's perspective)
+        # P_child is child.P (prior probability of selecting this child from parent)
+
+        N_parent_sqrt = math.sqrt(max(node.N, 1)) # max(node.N, 1) to prevent div by zero if node.N is 0 (e.g. root before playouts)
+
+        best_score = -float('inf')
+        best_child = None
+
+        for child_node in children_nodes:
+            Q = child_node.W / child_node.N if child_node.N > 0 else 0.0
+            # The value W in a child node is from its perspective.
+            # If the parent is player A, child is player B. MCTS aims to maximize value for the current player at the node.
+            # So, Q for player A from child (state B) should be - (value for B).
+            # However, W is stored as "sum of outcomes from this node's perspective".
+            # When backing up, v = -v. So child.W is already from parent's perspective if v was correctly flipped.
+            # Let's assume W is stored such that higher is better for the player whose turn it was at the *child* node.
+            # During backup: n.W += v (current node); v = -v (for parent).
+            # So, if node is current player, and child is opponent's turn, child.W is sum of (-v_parent).
+            # Q_child = child.W / child.N. This is the value from the child's perspective.
+            # We need value from parent's perspective. So, Q_parent = -Q_child.
+            # Let's re-evaluate the backup logic:
+            # Backup: path is [root, n1, n2, ..., leaf]. value is from leaf's perspective.
+            # for n in reversed(path): n.N +=1; n.W += v; v = -v.
+            # So, leaf.W += v_leaf. parent_of_leaf.W += (-v_leaf).
+            # This means W at each node is for the player *who made the move to get to that node*. This is not standard.
+            # Standard: W is sum of values for player whose turn it is *at that node*.
+            # If W is for player whose turn it is at node:
+            #   Q = node.W / node.N (value for current player)
+            #   Then for parent considering child: Q_parent_perspective = - (child.W / child.N)
+            # Let's adjust the selection to reflect this standard interpretation.
+            # The P attribute of a child node is the prior for the *action* that led to it.
+
+            # Simpler: Assume W is always from the perspective of the player whose turn it is at the node.
+            # When selecting a child of 'node', 'node' is current player. Child represents opponent's turn.
+            # So we want to pick child that MINIMIZES child.W / child.N (or maximizes -(child.W/child.N) )
+            # This seems to be a common source of confusion. AlphaZero PUCT: Q(s,a) + U(s,a)
+            # Q(s,a) is the mean action value of taking action a from state s.
+            # N(s,a) is visit count of action a from state s.
+            # W(s,a) is total action value of action a from state s. Q(s,a) = W(s,a)/N(s,a)
+            # P(s,a) is prior probability of action a from policy network.
+            # U(s,a) = c_puct * P(s,a) * sqrt(N(s)) / (1 + N(s,a)) where N(s) = sum over b of N(s,b)
+            # In this code, node.N is N(s). child.N is N(s,a). child.P is P(s,a).
+            # child.W seems to be W(s,a), but needs to be from perspective of player at s.
+
+            # Let's assume child.W is the sum of values from the perspective of the player at child.board.to_play.
+            # Since child.board.to_play is the opponent of node.board.to_play,
+            # the value for player at 'node' is - (child.W / child.N)
+            Q_for_parent = (-child_node.W / child_node.N) if child_node.N > 0 else 0.0
+
+            U = self.c_puct * child_node.P * N_parent_sqrt / (1 + child_node.N)
+            score = Q_for_parent + U
+
+            if score > best_score:
+                best_score = score
+                best_child = child_node
+
+        if best_child is None: # Should only happen if children list was empty, but we checked. Or if all scores are -inf.
+             # Fallback if all children have N=0 (e.g. first visit to this node's children)
+             # then Q=0 for all, pick based on U. If P is also 0 for some, issues.
+             # For now, let's assume P is non-zero for legal moves.
+             if not children_nodes: # Should be caught earlier
+                 raise Exception("No children to select from, this should not happen here.")
+             # This case might occur if all Q_for_parent are -inf and all U are 0 or -inf.
+             # This implies an issue with P (priors) or N_parent_sqrt.
+             # A simple fallback if all scores are terrible (e.g. all children lead to loss):
+             # just pick one, e.g. the first one or one with highest P.
+             # For now, rely on argmax behavior with floats.
+             # If all scores are identical (e.g. all 0 at start), torch.argmax picks first.
+             # This should be okay.
+             # If best_child is still None, this indicates an issue in logic or extreme values.
+             # For robustness, if best_child is None after loop, pick first child.
+             # This path should ideally not be taken if P values are reasonable.
+             # This situation could also arise if all children nodes have N=0, then Q=0.
+             # Then, selection is based on U = c_puct * P * sqrt(N_parent) / 1.
+             # So, child with highest P is chosen. This is correct.
+             # The code `torch.argmax(Q + U).item()` from original code would handle this fine.
+             # My loop is equivalent.
+             if not children_nodes: return children_nodes[0] # Should not be reachable
+
+        return best_child
+
+
+    def search(self, board: GoBoard) -> int: # board is GoBoard, no mask
         """Run MCTS playouts from ``board`` and return the best move index."""
 
-        root = MCTSNode(board.copy())
-        board_mask = mask.to(self.device)
+        root = MCTSNode(board.copy()) # Use GoBoard.copy()
 
         for _ in range(self.n_playouts):
             node = root
             path = [node]
 
             # Selection
-            while node.children:
+            while node.children: # While node is not a leaf in the *current search tree*
+                if node.board.is_terminal(): # If actual game terminal state, break selection
+                    break
                 node = self._uct_select(node)
                 path.append(node)
 
-            # Expansion
-            if node.features is None:
-                node.features = extract_features(node.board)
-            features = node.features.to(self.device)
-            # TODO: switch to GPU inference when available
+            # Expansion & Evaluation
+            # If node is terminal in game logic, its value is determined by game rules (win/loss/draw)
+            # For Go, this is complex (scoring). For now, model's value head will estimate.
+            # If we expanded down to a game terminal state, the model's value output will be used.
+
+            # features = extract_katago_features(node.board, self.config.in_channels) # Use new extraction
+            # features = features.to(self.device)
+
+            # Create legal moves mask for the model's policy head
+            # Shape (1, board_size, board_size), 1.0 for legal, 0.0 for illegal
+            # The model's policy head might expect -inf for illegal logits.
+            # For now, let's create a binary mask and assume model handles it or we adjust model output later.
+            # The model in `model.py` applies this mask by adding it to logits (expects 0 for legal, -inf for illegal).
+
+            policy_output_size = self.config.board_size * self.config.board_size + 1 # board_size^2 + 1 for pass
+
+            # This mask is for the *output* of the policy head (logits)
+            # It should be (1, policy_output_size)
+            # 0 for allowed moves, -infinity for disallowed moves.
+            policy_mask = torch.full((1, policy_output_size), 0.0, device=self.device, dtype=torch.float32)
+            for move_idx in range(policy_output_size):
+                 if not node.board.is_legal_move(move_idx):
+                    policy_mask[0, move_idx] = float('-inf')
+
+            # Prepare input features for the model
+            current_features = extract_katago_features(node.board, self.config.in_channels)
+            current_features = current_features.to(self.device)
+
             with torch.no_grad():
-                outputs = self.model(features, board_mask=board_mask.unsqueeze(0), use_inference_heads=True)
-            policy_logits = outputs["policy_logits"]
-            value = outputs["score_mean"].squeeze(0)
-            priors = torch.softmax(policy_logits, dim=1).squeeze(0)
+                # Pass policy_mask to the model if it supports it directly.
+                # The KataGoModel in model.py takes board_mask (spatial) not policy_mask (flat).
+                # It constructs its own policy_mask from board_mask internally before softmax.
+                # So we need to provide a spatial board_mask (0 for illegal, 1 for legal).
+                spatial_board_mask = torch.zeros(1, node.board.size, node.board.size, device=self.device, dtype=torch.float32)
+                for r_idx in range(node.board.size):
+                    for c_idx in range(node.board.size):
+                        move_idx = r_idx * node.board.size + c_idx
+                        if node.board.is_legal_move(move_idx):
+                            spatial_board_mask[0, r_idx, c_idx] = 1.0
+                # Pass move is implicitly handled by model if board_mask only covers board points.
+                # The model.py KataGoModel expects board_mask for policy head.
+
+                outputs = self.model(current_features, board_mask=spatial_board_mask, use_inference_heads=True)
+
+            policy_logits = outputs["policy_logits"].squeeze(0) # Shape: (policy_output_size,)
+            value = outputs["score_mean"].squeeze().item() # Scalar value
+
+            # Apply policy_mask to logits before softmax, if not done by model
+            # model.py already does this using the spatial_board_mask
+            # priors = torch.softmax(policy_logits, dim=0) # policy_logits should already be masked
+            priors = torch.softmax(policy_logits, dim=-1)
+
 
             if not node.board.is_terminal():
-                for move in node.board.legal_moves():
+                # Expand children for all legal moves
+                for move in node.board.legal_moves(): # Uses new GoBoard.legal_moves()
                     if move not in node.children:
-                        next_board = node.board.copy()
-                        next_board.play(move)
-                        node.children[move] = MCTSNode(next_board, parent=node, P=priors[move].item())
+                        next_board_state = node.board.copy()
+                        next_board_state.play_move(move)
+                        # Prior P for the child is P(action_that_leads_to_child | parent_state)
+                        node.children[move] = MCTSNode(next_board_state, parent=node, P=priors[move].item())
 
-            # Backup
-            v = value.item()
-            for n in reversed(path):
-                n.N += 1
-                n.W += v
-                v = -v
+            # Backup: Propagate value (-v for parent) up the path
+            # v is from the perspective of the player *at the current node (node.board.to_play)*
+            v = value
+            for selected_node_in_path in reversed(path):
+                selected_node_in_path.N += 1
+                # W should accumulate value from perspective of player at selected_node_in_path
+                selected_node_in_path.W += v
+                v = -v # Flip value for the parent
 
         if not root.children:
-            return board.size * board.size
-        actions = list(root.children.keys())
-        visits = [root.children[a].N for a in actions]
-        best_idx = visits.index(max(visits))
-        return actions[best_idx]
+            # This can happen if n_playouts is 0 or if the root is a terminal state
+            # and no children were ever expanded (e.g. if expansion only happens for non-terminal)
+            # If root is terminal, it should ideally have a value, but no best move.
+            # GTP spec requires a move or 'resign'. If no moves, pass.
+            if board.is_terminal(): # board is initial board passed to search
+                 return board.PASS_MOVE # Or handle terminal state appropriately
+
+            # If no children after playouts (e.g. n_playouts=0 or immediate terminal state)
+            # Fallback: try to list legal moves from the root board.
+            # This part of code means "what move to play *from root*".
+            # If no children were generated, it means we didn't even run the loop once for the root.
+            # This implies n_playouts was < 1 or some other early exit.
+            # A robust MCTS should at least evaluate root, get priors, and pick based on that if n_playouts is very small.
+            # The loop for _ in range(self.n_playouts) handles this.
+            # So, if root.children is empty, it implies root state itself is terminal and expansion didn't add children.
+            # Or, if all legal moves from root lead to immediate terminal states.
+            # This situation needs graceful handling. For now, if no children, pass.
+            return board.PASS_MOVE
+
+
+        # Select best move from root based on visit counts (most robust)
+        # or max value (Q value), or a combination. Typically visit counts.
+        best_move = -1
+        max_visits = -1
+        for move, child_node in root.children.items():
+            if child_node.N > max_visits:
+                max_visits = child_node.N
+                best_move = move
+
+        if best_move == -1: # Should not happen if root.children is not empty
+            # Fallback if all children have 0 visits (e.g. if n_playouts was too small to visit children of root's children)
+            # In such a case, priors from the first evaluation of root would be in root.children[move].P
+            # We could pick based on highest prior if all N are 0.
+            # However, the MCTS loop ensures each child of root is created with a P.
+            # If n_playouts = 1, one path is explored. Root's children are created. One of them gets N=1.
+            # So this fallback should ideally not be needed.
+            # If there are children, at least one must have N>0 if any playouts happened.
+            # If n_playouts = 0, this function should probably not be called or handle it differently.
+            # If it's still -1, it means root.children was not empty but all N were <= -1 (impossible).
+            # Or, if root.children was empty, which is handled above.
+            # One last check: if all children have N=0 (e.g. after one simulation that ends at root)
+            # then pick child with highest prior P.
+            if max_visits == 0:
+                max_prior = -1.0
+                for move, child_node in root.children.items():
+                    if child_node.P > max_prior:
+                        max_prior = child_node.P
+                        best_move = move
+            if best_move == -1 and root.children: # Still no best move, pick first available
+                best_move = list(root.children.keys())[0]
+            elif not root.children: # no children at all
+                return board.PASS_MOVE
+
+
+        return best_move
 
 
 if __name__ == "__main__":
-    config = ModelConfig(board_size=5, in_channels=28)
-    model = KataGoModel(config)
-    board = MinimalGoBoard(size=5)
-    mask = torch.ones(config.board_size, config.board_size, dtype=torch.float32)
-    mcts = MCTS(model, config, n_playouts=100)
-    best = mcts.search(board, mask)
-    print("Best move index:", best)
+    # Ensure ModelConfig and KataGoModel are imported correctly
+    # from model import ModelConfig, KataGoModel
+    # from board import GoBoard
+
+    print("MCTS Self-Test with GoBoard")
+    config = ModelConfig(board_size=5, in_channels=22) # features.py expects up to 22
+    model = KataGoModel(config) # model.py uses config.in_channels
+
+    # Check if config.in_channels is what extract_katago_features expects
+    # The features.py uses model_channels argument.
+    # ModelConfig has in_channels. Let's assume they are the same.
+
+    board = GoBoard(size=5)
+
+    # Play a few moves on the board for a more interesting test
+    board.play_move(board.coords_to_idx(2,2)) # B
+    board.play_move(board.coords_to_idx(2,3)) # W
+    board.play_move(board.coords_to_idx(3,2)) # B
+    board.play_move(board.coords_to_idx(3,3)) # W
+    print("Board state for MCTS test:")
+    print(board)
+
+    mcts = MCTS(model, config, n_playouts=16) # Reduced playouts for faster test
+
+    print("Running MCTS search...")
+    # Pass the GoBoard instance directly, no mask tensor
+    best_move_idx = mcts.search(board)
+
+    if best_move_idx == board.PASS_MOVE:
+        print(f"Best move: PASS")
+    else:
+        r, c = best_move_idx // board.size, best_move_idx % board.size
+        print(f"Best move index: {best_move_idx} ({r},{c})")
+
+    # Example of playing the move
+    # board.play_move(best_move_idx)
+    # print("\nBoard after MCTS move:")
+    # print(board)
 


### PR DESCRIPTION
This commit integrates a robust Go board representation, KataGo-style feature extraction, and enhances the GTP command suite.

Key changes:
- The engine now uses the KataGoModel defined in `model.py` with ModelConfig.
- I introduced `board.py` with a `GoBoard` class handling detailed game logic: liberties, captures, ko, history, and move validation.
- I added `features.py` with `extract_katago_features` to generate multi-plane input tensors for the model based on `GoBoard` state.
- I integrated `GoBoard` and new feature extraction into MCTS and the `genmove` GTP command.
- I removed `MinimalGoBoard` and its associated simplistic feature extraction.
- I implemented GTP commands: `known_command`, `list_commands`, `komi`, `get_komi`.
- I refined `play`, `clear_board`, and `boardsize` GTP commands for consistency with `GoBoard` and fixed model sizing.

The engine is now structured to work with its internal (untrained) model and provides a more complete GTP interface. Next steps would involve unit testing and further GTP command implementation or model training.