### PR TITLE
Add .gitignore for pycache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc


### PR DESCRIPTION
## Summary
- add `.gitignore` to ignore `__pycache__/` and `*.pyc`
- no pycache directories were tracked, so none removed

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6848f19c06fc832186500d7ebdb3c406